### PR TITLE
feat(newsletter): automate weekly issue generation and sending

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
+# Every change needs the maintainer's review.
+# Path rules keep the guard rails (data, validators, workflows) explicitly owned.
+
 * @kawacukennedy
+
+/data/ @kawacukennedy
+/scripts/ @kawacukennedy
+/site/ @kawacukennedy
+/.github/ @kawacukennedy

--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -1,0 +1,26 @@
+name: newsletter
+
+on:
+  schedule:
+    - cron: "0 9 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - name: Validate dataset
+        run: python3 scripts/validate.py
+      - name: Generate and send weekly issue
+        env:
+          BUTTONDOWN_API_TOKEN: ${{ secrets.BUTTONDOWN_API_TOKEN }}
+        run: python3 scripts/newsletter.py --send

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/build_site.py`: version hash now includes site sources
   (`app.js`, `styles.css`, `index.html`, `data/africa.js`) so asset URLs
   rotate whenever either the dataset or the site code changes.
+- Security hardening: all dataset-derived strings are HTML-escaped before
+  being rendered by `site/app.js`, and `scripts/validate.py` now rejects
+  markup characters (`<`, `>`) in string fields so a compromised data PR
+  cannot inject script into the live site.
+- `CODEOWNERS`: explicit path rules for `/data/`, `/scripts/`, `/site/` and
+  `/.github/` so guard-rail changes always require maintainer review.
+- Free weekly newsletter: `/newsletter` page with Buttondown subscribe form
+  (free tier, no watermarks) and a public issue archive on GitHub Pages.
+  Homepage and footer link to it; `scripts/build_site.py` copies and
+  cache-busts newsletter pages. Issue 001 published.
+- Fully automated newsletter pipeline: `scripts/newsletter.py` generates a
+  weekly digest from the dataset and sends it via the Buttondown API
+  (`scripts/newsletter.py --draft` to stage, `--send` to publish); the
+  `newsletter` GitHub Actions workflow sends every Tuesday at 09:00 UTC and on
+  manual dispatch. Subscribe forms use the real Buttondown username `kawacu`;
+  the newsletter page links to the canonical live archive.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ python3 examples/quickstart.py
 
 See [`docs/roadmap.md`](docs/roadmap.md). Near-term: expand country coverage, add an "IAEA 19 infrastructure issues" readiness tracker per country, and a live web map.
 
+## Newsletter
+
+Get the free weekly briefing — new records, corrections, and the wider African
+energy picture, all sourced: **[newsletter.html](site/newsletter.html)**.
+
 ## Contributing
 
 Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first. Data corrections, new countries, and methodology improvements are especially welcome. All contributions must include sources.

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -24,7 +24,7 @@ def main():
     n = len(dataset["countries"])
 
     site_hash = hashlib.sha256(raw.encode("utf-8"))
-    for rel in ("app.js", "styles.css", "index.html", "data/africa.js"):
+    for rel in ("app.js", "styles.css", "index.html", "data/africa.js", "newsletter.html"):
         site_hash.update((SITE / rel).read_bytes())
     version = site_hash.hexdigest()[:8]
 
@@ -57,6 +57,26 @@ def main():
     html = html.replace("data/africa.js?v=__VER__", renamed["data/africa.js"])
     html = html.replace("app.js?v=__VER__", renamed["app.js"])
     (DIST / "index.html").write_text(html, encoding="utf-8")
+
+    for rel in ("newsletter.html",):
+        src = SITE / rel
+        if not src.exists():
+            continue
+        text = src.read_text(encoding="utf-8")
+        text = text.replace("styles.css?v=__VER__", renamed["styles.css"])
+        text = text.replace("data/dataset.js?v=__VER__", renamed["data/dataset.js"])
+        text = text.replace("data/africa.js?v=__VER__", renamed["data/africa.js"])
+        text = text.replace("app.js?v=__VER__", renamed["app.js"])
+        dst = DIST / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(text, encoding="utf-8")
+
+    for src in (SITE / "newsletter").glob("*.html"):
+        text = src.read_text(encoding="utf-8")
+        text = text.replace("styles.css?v=__VER__", renamed["styles.css"])
+        dst = DIST / "newsletter" / src.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(text, encoding="utf-8")
 
     print(f"build: wrote {DIST} ({n} countries, ver {version})")
     for name in sorted(renamed.values()):

--- a/scripts/newsletter.py
+++ b/scripts/newsletter.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Generate and send the AfrPowerOS Weekly newsletter via the Buttondown API.
+
+Stdlib-only. Reads BUTTONDOWN_API_TOKEN from the environment or a .env file
+in the repo root.
+
+Usage:
+  python3 scripts/newsletter.py --draft    # create a draft, do not send
+  python3 scripts/newsletter.py --send     # create draft, then send immediately
+  python3 scripts/newsletter.py --dry-run  # print the issue without calling the API
+"""
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA = ROOT / "data"
+SITE = ROOT / "site"
+ISSUES_DIR = SITE / "newsletter"
+API = "https://api.buttondown.com/v1"
+ARCHIVE_URL = "https://buttondown.com/kawacu/archive/"
+
+
+def load_token():
+    env = os.environ.get("BUTTONDOWN_API_TOKEN")
+    if env:
+        return env.strip()
+    env_file = ROOT / ".env"
+    if env_file.exists():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("BUTTONDOWN_API_TOKEN="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    return None
+
+
+def api_request(method, path, payload=None, token=None):
+    req = urllib.request.Request(API + path, method=method)
+    req.add_header("Authorization", f"Token {token}")
+    req.add_header("X-API-Version", "2026-04-01")
+    req.add_header("Content-Type", "application/json")
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    try:
+        with urllib.request.urlopen(req, data=body, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+            return resp.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        return exc.code, {"error": detail}
+
+
+def next_issue_number():
+    nums = []
+    if ISSUES_DIR.exists():
+        for p in ISSUES_DIR.glob("issue-*.html"):
+            m = re.match(r"issue-(\d+)\.html", p.name)
+            if m:
+                nums.append(int(m.group(1)))
+    return (max(nums) + 1) if nums else 1
+
+
+def dataset_changes_since(days=7):
+    changes = []
+    try:
+        since = (datetime.date.today() - datetime.timedelta(days=days)).isoformat()
+        out = subprocess.run(
+            ["git", "log", f"--since={since}", "--oneline", "--", "data/afrpoweros.json"],
+            capture_output=True, text=True, cwd=ROOT,
+        ).stdout
+        for line in out.splitlines():
+            changes.append(line.strip())
+    except Exception:
+        pass
+    return changes
+
+
+def build_issue():
+    with open(DATA / "afrpoweros.json", encoding="utf-8") as fh:
+        dataset = json.load(fh)
+    countries = dataset["countries"]
+    n = len(countries)
+
+    statuses = {}
+    verified = 0
+    for rec in countries:
+        s = rec.get("program_status", "None")
+        statuses[s] = statuses.get(s, 0) + 1
+        if rec.get("confidence") == "Verified":
+            verified += 1
+
+    label = {
+        "Operating": "operating a commercial plant",
+        "Under Construction": "under construction",
+        "Announced": "announced",
+        "Preparing": "preparing",
+        "Exploring": "exploring",
+        "None": "no active program",
+    }
+
+    status_lines = "\n".join(
+        f"- **{count}** {label.get(s, s.lower())}" for s, count in sorted(statuses.items(), key=lambda kv: -kv[1])
+    )
+
+    changes = dataset_changes_since()
+    change_block = "\n".join(f"- `{c}`" for c in changes[:8]) if changes else "None this week — records carried over from prior verification."
+
+    body = f"""# AfrPowerOS Weekly
+
+{datetime.date.today().isoformat()} · {n} countries tracked · every fact sourced
+
+## This week in the dataset
+
+{status_lines}
+
+**Confidence:** {verified} of {n} records `Verified` from primary sources.
+
+**Dataset changes (last 7 days):**
+{change_block}
+
+## Why this matters
+
+Africa hosts under 2% of global data-center capacity, and ~600 million people in sub-Saharan Africa lack electricity. Power — not compute — is the binding constraint on the continent's AI and industrial future. AfrPowerOS tracks the civilian nuclear programs emerging to close that gap.
+
+## Explore the data
+
+- Live map: https://kawacukennedy.github.io/afrpoweros/
+- Full dataset: https://github.com/kawacukennedy/afrpoweros/blob/main/data/afrpoweros.json
+- Corrections welcome: https://github.com/kawacukennedy/afrpoweros/issues
+- Archive: {ARCHIVE_URL}
+
+*Every record carries a confidence label (Verified / Inference / Speculation / Unverified). Nothing is invented — if we can't source it, we mark it or omit it. No hype, no ads.*
+"""
+    subject = f"AfrPowerOS Weekly · {n} countries, {verified} verified · {datetime.date.today().isoformat()}"
+    return subject, body
+
+
+def write_archive_page(issue_num, subject, body):
+    ISSUES_DIR.mkdir(parents=True, exist_ok=True)
+    date = datetime.date.today().isoformat()
+    html_body = body.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    html_body = html_body.replace("\n", "<br>")
+    page = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Issue {issue_num:03d} — AfrPowerOS Weekly</title>
+  <link rel="stylesheet" href="../styles.css?v=__VER__">
+</head>
+<body>
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="/"><span class="brand-dot"></span><span>AfrPowerOS</span></a>
+      <nav class="nav-links">
+        <a href="/#map">Map</a>
+        <a href="/#table">Countries</a>
+        <a href="../newsletter.html">Newsletter</a>
+        <a class="nav-cta" href="https://github.com/kawacukennedy/afrpoweros">GitHub</a>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <article class="issue">
+      <p class="eyebrow">Issue {issue_num:03d} · {date}</p>
+      <h1>{subject.replace('<', '&lt;').replace('>', '&gt;')}</h1>
+      <p>{html_body}</p>
+      <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/kawacu" method="post" target="_blank">
+        <input type="email" name="email" placeholder="you@example.com" required>
+        <button type="submit" class="btn btn-primary">Subscribe free</button>
+      </form>
+    </article>
+  </main>
+  <footer class="footer">
+    <p>AfrPowerOS · MIT code · CC BY 4.0 data</p>
+    <p><a href="https://github.com/kawacukennedy/afrpoweros">github.com/kawacukennedy/afrpoweros</a> · <a href="https://github.com/kawacukennedy/afrpoweros/issues">Issues</a></p>
+  </footer>
+</body>
+</html>
+"""
+    path = ISSUES_DIR / f"issue-{issue_num:03d}.html"
+    path.write_text(page, encoding="utf-8")
+    return path
+
+
+def update_archive_index(issue_num, subject):
+    index = SITE / "newsletter.html"
+    if not index.exists():
+        return
+    text = index.read_text(encoding="utf-8")
+    date = datetime.date.today().isoformat()
+    li = f'<li><a href="newsletter/issue-{issue_num:03d}.html">Issue {issue_num:03d} — {subject}</a> <span class="newsletter-date">· {date}</span></li>'
+    if f'issue-{issue_num:03d}.html' in text:
+        return
+    marker = '<ul class="archive-list">'
+    if marker in text:
+        text = text.replace(marker, marker + "\n        " + li, 1)
+        index.write_text(text, encoding="utf-8")
+
+
+def main():
+    mode = "draft"
+    if "--send" in sys.argv:
+        mode = "send"
+    elif "--dry-run" in sys.argv:
+        mode = "dry-run"
+
+    subject, body = build_issue()
+    issue_num = next_issue_number()
+    print(f"Issue {issue_num:03d}: {subject}")
+    print("=" * 60)
+    print(body)
+
+    if mode == "dry-run":
+        print("dry-run: no API call made")
+        return 0
+
+    token = load_token()
+    if not token:
+        print("FATAL: BUTTONDOWN_API_TOKEN not set (env or .env)", file=sys.stderr)
+        return 1
+
+    status, created = api_request(
+        "POST", "/emails",
+        {"subject": subject, "body": body, "status": "draft"},
+        token=token,
+    )
+    if status not in (200, 201):
+        print(f"FATAL: create email failed ({status}): {created}", file=sys.stderr)
+        return 1
+    email_id = created.get("id")
+    url = created.get("absolute_url", "")
+    print(f"draft created: {email_id} {url}")
+
+    if mode == "send":
+        st2, updated = api_request(
+            "PATCH", f"/emails/{email_id}",
+            {"status": "about_to_send"},
+            token=token,
+        )
+        if st2 != 200:
+            print(f"FATAL: send failed ({st2}): {updated}", file=sys.stderr)
+            return 1
+        print(f"SENT: {updated.get('absolute_url', url)}")
+
+    page = write_archive_page(issue_num, subject, body)
+    update_archive_index(issue_num, subject)
+    print(f"archive page: {page}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -84,6 +84,13 @@ def check_string(value, field, country):
         fail(f"{country}: {field} must be a non-empty string")
 
 
+def check_no_markup(value, field, country):
+    if not isinstance(value, str):
+        return
+    if "<" in value or ">" in value:
+        fail(f"{country}: {field} must not contain markup characters < or >")
+
+
 def check_string_list(value, field, country, min_items=0):
     if not isinstance(value, list):
         fail(f"{country}: {field} must be a list")
@@ -167,6 +174,12 @@ def main():
         check_string_list(record.get("vendors"), "vendors", country)
         check_string_list(record.get("agreements"), "agreements", country)
         check_string_list(record.get("sources"), "sources", country, min_items=1)
+
+        for field in ("country", "regulator", "implementing_agency", "research_reactor", "notes"):
+            check_no_markup(record.get(field), field, country)
+        for event in record.get("key_events", []):
+            if isinstance(event, dict):
+                check_no_markup(event.get("title"), "key_event title", country)
 
         if not record.get("sources"):
             fail(f"{country}: must have at least one source")

--- a/site/app.js
+++ b/site/app.js
@@ -27,6 +27,12 @@
     None: "#8e8e93"
   };
 
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
   var NAME_ALIAS = {
     Tanzania: "United Republic of Tanzania",
     "Congo (Dem. Rep.)": "Dem. Rep. Congo",
@@ -145,15 +151,15 @@
   function tooltipHTML(f) {
     var rec = recFor(f);
     if (!rec) {
-      return "<h4>" + f.name + "</h4><p>No record yet — contribute one.</p>";
+      return "<h4>" + esc(f.name) + "</h4><p>No record yet — contribute one.</p>";
     }
     var lines = [];
-    lines.push("<strong>" + rec.program_status + "</strong>");
-    if (rec.iaea_milestone_phase) lines.push("IAEA Phase " + rec.iaea_milestone_phase);
-    if (rec.capacity_gw_planned) lines.push(rec.capacity_gw_planned + " GW planned");
-    if (rec.first_grid_target_year) lines.push("Grid ~" + rec.first_grid_target_year);
-    lines.push(rec.confidence + " · " + rec.last_verified);
-    return "<h4>" + rec.country + "</h4><p>" + lines.join(" · ") + "</p>";
+    lines.push("<strong>" + esc(rec.program_status) + "</strong>");
+    if (rec.iaea_milestone_phase) lines.push("IAEA Phase " + esc(rec.iaea_milestone_phase));
+    if (rec.capacity_gw_planned) lines.push(esc(rec.capacity_gw_planned) + " GW planned");
+    if (rec.first_grid_target_year) lines.push("Grid ~" + esc(rec.first_grid_target_year));
+    lines.push(esc(rec.confidence) + " · " + esc(rec.last_verified));
+    return "<h4>" + esc(rec.country) + "</h4><p>" + lines.join(" · ") + "</p>";
   }
 
   svg.addEventListener("mousemove", function (e) {
@@ -201,15 +207,15 @@
     .sort(function (a, b) { return a.country.localeCompare(b.country); })
     .forEach(function (rec) {
       tpl.innerHTML =
-        '<tr id="row-' + rec.country.replace(/\s+/g, "-") + '">' +
-        "<td><strong>" + rec.country + "</strong></td>" +
+        '<tr id="row-' + esc(rec.country.replace(/\s+/g, "-")) + '">' +
+        "<td><strong>" + esc(rec.country) + "</strong></td>" +
         '<td><span class="tag" style="background:' + STATUS_COLOR[rec.program_status] + '">' +
         STATUS_LABEL[rec.program_status] + "</span></td>" +
-        "<td>" + (rec.iaea_milestone_phase || "—") + "</td>" +
-        "<td>" + (rec.capacity_gw_planned != null ? rec.capacity_gw_planned + " GW" : "—") + "</td>" +
-        "<td>" + (rec.first_grid_target_year || "—") + "</td>" +
-        "<td>" + rec.regulator + "</td>" +
-        '<td><span class="tag tag-unverified">' + rec.confidence + "</span></td>" +
+        "<td>" + esc(rec.iaea_milestone_phase || "—") + "</td>" +
+        "<td>" + esc(rec.capacity_gw_planned != null ? rec.capacity_gw_planned + " GW" : "—") + "</td>" +
+        "<td>" + esc(rec.first_grid_target_year || "—") + "</td>" +
+        "<td>" + esc(rec.regulator) + "</td>" +
+        '<td><span class="tag tag-unverified">' + esc(rec.confidence) + "</span></td>" +
         "</tr>";
       tableBody.appendChild(tpl.content.firstChild);
     });

--- a/site/index.html
+++ b/site/index.html
@@ -19,6 +19,7 @@
         <a href="#table">Countries</a>
         <a href="#method">Method</a>
         <a href="#contribute">Contribute</a>
+        <a href="newsletter.html">Newsletter</a>
         <a class="nav-cta" href="https://github.com/kawacukennedy/afrpoweros">GitHub</a>
       </nav>
     </div>
@@ -90,11 +91,25 @@
         </div>
       </div>
     </section>
+
+    <section class="contribute">
+      <div class="contribute-card">
+        <h2>Get the weekly briefing</h2>
+        <p>
+          New records, corrections, and the wider African energy picture — sourced and
+          concise. Free, no spam, unsubscribe anytime.
+        </p>
+        <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/kawacu" method="post" target="_blank">
+          <input type="email" name="email" placeholder="you@example.com" required>
+          <button type="submit" class="btn btn-primary">Subscribe free</button>
+        </form>
+      </div>
+    </section>
   </main>
 
   <footer class="footer">
     <p>AfrPowerOS · MIT code · CC BY 4.0 data</p>
-    <p><a href="https://github.com/kawacukennedy/afrpoweros">github.com/kawacukennedy/afrpoweros</a> · <a href="https://github.com/kawacukennedy/afrpoweros/issues">Issues</a></p>
+    <p><a href="https://github.com/kawacukennedy/afrpoweros">github.com/kawacukennedy/afrpoweros</a> · <a href="https://github.com/kawacukennedy/afrpoweros/issues">Issues</a> · <a href="newsletter.html">Newsletter</a></p>
   </footer>
 
   <script src="data/dataset.js?v=__VER__" defer></script>

--- a/site/newsletter.html
+++ b/site/newsletter.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AfrPowerOS Weekly — African Nuclear &amp; Energy Infrastructure</title>
+  <meta name="description" content="A weekly, evidence-first briefing on Africa's civilian nuclear and energy programs. Free. Every fact sourced.">
+  <link rel="stylesheet" href="styles.css?v=__VER__">
+</head>
+<body>
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="/">
+        <span class="brand-dot"></span>
+        <span>AfrPowerOS</span>
+      </a>
+      <nav class="nav-links">
+        <a href="/#map">Map</a>
+        <a href="/#table">Countries</a>
+        <a href="/#method">Method</a>
+        <a href="newsletter.html">Newsletter</a>
+        <a class="nav-cta" href="https://github.com/kawacukennedy/afrpoweros">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="eyebrow">Free weekly briefing · evidence-first</p>
+      <h1>AfrPowerOS Weekly</h1>
+      <p class="hero-sub">
+        What actually changed in Africa's nuclear and energy programs this week —
+        sourced, confidence-labelled, and written so you can skim in 5 minutes.
+      </p>
+      <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/kawacu" method="post" target="_blank">
+        <input type="email" name="email" placeholder="you@example.com" required>
+        <button type="submit" class="btn btn-primary">Subscribe free</button>
+      </form>
+      <p class="newsletter-note">No spam. Unsubscribe anytime. ~600 words a week.</p>
+    </section>
+
+    <section class="card newsletter-archive">
+      <h2>Past issues</h2>
+      <ul class="archive-list">
+        <li><a href="newsletter/issue-002.html">Issue 002 — AfrPowerOS Weekly · 20 countries, 20 verified · 2026-08-16</a> <span class="newsletter-date">· 2026-08-16</span></li>
+        <li><a href="newsletter/issue-001.html">Issue 001 — Why I'm building a sourced tracker for Africa's nuclear plans</a></li>
+      </ul>
+      <p class="newsletter-note">
+        The canonical archive lives on Buttondown (<a href="https://buttondown.com/kawacu/archive/">buttondown.com/kawacu/archive</a>) — every issue is published there and mirrored here.
+      </p>
+    </section>
+
+    <section class="contribute" id="contribute">
+      <div class="contribute-card">
+        <h2>See something wrong?</h2>
+        <p>
+          Every issue is built on the AfrPowerOS dataset. Corrections are public
+          and welcome — open an issue or submit a pull request.
+        </p>
+        <div class="contribute-actions">
+          <a class="btn btn-primary" href="https://github.com/kawacukennedy/afrpoweros/issues">Open an issue</a>
+          <a class="btn" href="https://github.com/kawacukennedy/afrpoweros/blob/main/docs/methodology.md">Methodology</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>AfrPowerOS · MIT code · CC BY 4.0 data</p>
+    <p><a href="https://github.com/kawacukennedy/afrpoweros">github.com/kawacukennedy/afrpoweros</a> · <a href="https://github.com/kawacukennedy/afrpoweros/issues">Issues</a></p>
+  </footer>
+</body>
+</html>

--- a/site/newsletter/issue-001.html
+++ b/site/newsletter/issue-001.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Issue 001 — AfrPowerOS Weekly</title>
+  <link rel="stylesheet" href="../styles.css?v=__VER__">
+</head>
+<body>
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="/">
+        <span class="brand-dot"></span>
+        <span>AfrPowerOS</span>
+      </a>
+      <nav class="nav-links">
+        <a href="/#map">Map</a>
+        <a href="/#table">Countries</a>
+        <a href="/#method">Method</a>
+        <a href="../newsletter.html">Newsletter</a>
+        <a class="nav-cta" href="https://github.com/kawacukennedy/afrpoweros">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <article class="issue">
+      <p class="eyebrow">Issue 001 · 16 Aug 2026</p>
+      <h1>Why I'm building a sourced tracker for Africa's nuclear plans</h1>
+
+      <p>
+        Only one African country operates a commercial nuclear plant: South Africa.
+        A second, Egypt, is building one. And a growing list of countries — Ghana,
+        Kenya, Uganda, Tanzania, Nigeria, Rwanda, Sudan, Zambia, Ethiopia and others —
+        are actively preparing or exploring.
+      </p>
+
+      <p>
+        The problem: there is no neutral, cited, machine-readable place to see it all.
+        Announcements are scattered across government sites, IAEA press releases,
+        and industry media. Following them means refreshing a dozen sources by hand.
+      </p>
+
+      <p>So I'm building that place. It's called AfrPowerOS.</p>
+
+      <h2>How it works</h2>
+      <ul>
+        <li>Every record carries a confidence label — Verified, Inference, Speculation, or Unverified.</li>
+        <li>Every fact has a source URL. No exceptions.</li>
+        <li>Corrections go in as public pull requests, so the history is auditable.</li>
+      </ul>
+
+      <h2>20 countries, all sourced</h2>
+      <p>
+        The dataset currently covers 20 African countries: Rwanda, Kenya, Ghana, Egypt,
+        South Africa, Uganda, Tanzania, Nigeria, Zambia, Morocco, Algeria, Ethiopia,
+        Sudan, Tunisia, Zimbabwe, Senegal, Mali, Niger, Eswatini and DR Congo.
+      </p>
+
+      <h2>This week in numbers</h2>
+      <ul>
+        <li><strong>1</strong> country operating a commercial reactor (South Africa)</li>
+        <li><strong>1</strong> under construction (Egypt)</li>
+        <li><strong>7</strong> preparing or announced</li>
+        <li><strong>10</strong> exploring</li>
+      </ul>
+
+      <h2>Why subscribe</h2>
+      <p>
+        Each week I summarize what changed: new records, corrections, methodology
+        updates, and a note on the wider African energy picture. No hype, no ads —
+        just sourced facts you can verify.
+      </p>
+
+      <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/kawacu" method="post" target="_blank">
+        <input type="email" name="email" placeholder="you@example.com" required>
+        <button type="submit" class="btn btn-primary">Subscribe free</button>
+      </form>
+
+      <p class="newsletter-note">
+        Explore the live map: <a href="/">kawacukennedy.github.io/afrpoweros</a>
+      </p>
+    </article>
+  </main>
+
+  <footer class="footer">
+    <p>AfrPowerOS · MIT code · CC BY 4.0 data</p>
+    <p><a href="https://github.com/kawacukennedy/afrpoweros">github.com/kawacukennedy/afrpoweros</a> · <a href="https://github.com/kawacukennedy/afrpoweros/issues">Issues</a></p>
+  </footer>
+</body>
+</html>

--- a/site/newsletter/issue-002.html
+++ b/site/newsletter/issue-002.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Issue 002 — AfrPowerOS Weekly</title>
+  <link rel="stylesheet" href="../styles.css?v=__VER__">
+</head>
+<body>
+  <header class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="/"><span class="brand-dot"></span><span>AfrPowerOS</span></a>
+      <nav class="nav-links">
+        <a href="/#map">Map</a>
+        <a href="/#table">Countries</a>
+        <a href="../newsletter.html">Newsletter</a>
+        <a class="nav-cta" href="https://github.com/kawacukennedy/afrpoweros">GitHub</a>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <article class="issue">
+      <p class="eyebrow">Issue 002 · 2026-08-16</p>
+      <h1>AfrPowerOS Weekly · 20 countries, 20 verified · 2026-08-16</h1>
+      <p># AfrPowerOS Weekly<br><br>2026-08-16 · 20 countries tracked · every fact sourced<br><br>## This week in the dataset<br><br>- **10** exploring<br>- **7** preparing<br>- **1** under construction<br>- **1** operating a commercial plant<br>- **1** no active program<br><br>**Confidence:** 20 of 20 records `Verified` from primary sources.<br><br>**Dataset changes (last 7 days):**<br>- `ab01979 feat(data): expand dataset to 20 countries, add homepage contribute CTA`<br>- `95663bd feat: initial AfrPowerOS dataset and open-source project skeleton`<br><br>## Why this matters<br><br>Africa hosts under 2% of global data-center capacity, and ~600 million people in sub-Saharan Africa lack electricity. Power — not compute — is the binding constraint on the continent's AI and industrial future. AfrPowerOS tracks the civilian nuclear programs emerging to close that gap.<br><br>## Explore the data<br><br>- Live map: https://kawacukennedy.github.io/afrpoweros/<br>- Full dataset: https://github.com/kawacukennedy/afrpoweros/blob/main/data/afrpoweros.json<br>- Corrections welcome: https://github.com/kawacukennedy/afrpoweros/issues<br>- Archive: https://buttondown.com/kawacu/archive/<br><br>*Every record carries a confidence label (Verified / Inference / Speculation / Unverified). Nothing is invented — if we can't source it, we mark it or omit it. No hype, no ads.*<br></p>
+      <form class="newsletter-form" action="https://buttondown.com/api/emails/embed-subscribe/kawacu" method="post" target="_blank">
+        <input type="email" name="email" placeholder="you@example.com" required>
+        <button type="submit" class="btn btn-primary">Subscribe free</button>
+      </form>
+    </article>
+  </main>
+  <footer class="footer">
+    <p>AfrPowerOS · MIT code · CC BY 4.0 data</p>
+    <p><a href="https://github.com/kawacukennedy/afrpoweros">github.com/kawacukennedy/afrpoweros</a> · <a href="https://github.com/kawacukennedy/afrpoweros/issues">Issues</a></p>
+  </footer>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -334,6 +334,71 @@ tbody tr.highlight { animation: flash 2s ease; }
   border-color: transparent;
 }
 
+.newsletter-form {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+
+.newsletter-form input[type="email"] {
+  padding: 10px 16px;
+  border-radius: 980px;
+  border: 1px solid var(--line);
+  font-size: 14px;
+  font-family: inherit;
+  background: var(--card);
+  min-width: 260px;
+  color: var(--text);
+}
+
+.newsletter-form input[type="email"]:focus {
+  outline: none;
+  border-color: var(--pr);
+}
+
+.newsletter-form button { border: none; cursor: pointer; }
+
+.newsletter-note { color: var(--text-2); font-size: 13px; margin-top: 14px; }
+
+.newsletter-archive {
+  max-width: 640px;
+  margin: 0 auto 80px;
+  padding: 32px 36px;
+}
+
+.newsletter-archive h2 { font-size: 22px; font-weight: 700; margin-bottom: 16px; }
+
+.archive-list { list-style: none; }
+
+.archive-list li { padding: 10px 0; border-bottom: 1px solid var(--line); }
+
+.archive-list a { color: var(--text); text-decoration: none; font-weight: 500; }
+.archive-list a:hover { color: var(--pr); }
+
+.issue {
+  max-width: 640px;
+  margin: 0 auto 80px;
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 48px;
+}
+
+.issue h1 { font-size: 32px; font-weight: 700; letter-spacing: -0.01em; margin: 4px 0 20px; }
+.issue h2 { font-size: 20px; font-weight: 700; margin: 28px 0 10px; }
+.issue p { color: var(--text-2); font-size: 15px; margin-bottom: 14px; }
+.issue ul { color: var(--text-2); font-size: 15px; margin: 0 0 14px 20px; }
+.issue li { margin-bottom: 6px; }
+.issue a { color: var(--pr); text-decoration: none; }
+.issue .newsletter-form { justify-content: flex-start; margin-top: 24px; }
+
+@media (max-width: 720px) {
+  .issue { padding: 28px 20px; }
+  .newsletter-archive { padding: 24px 20px; }
+}
+
 .footer {
   text-align: center;
   padding: 40px 24px 56px;


### PR DESCRIPTION
## What

Automates the AfrPowerOS Weekly newsletter end-to-end so issues publish with zero manual steps:

- **scripts/newsletter.py** — stdlib-only generator that digests `data/afrpoweros.json` into a weekly issue, creates the email via the Buttondown API (`--draft` stages, `--send` publishes), and writes the public archive page under `site/newsletter/`.
- **newsletter GitHub Actions workflow** — weekly cron (Tue 09:00 UTC) + manual dispatch; validates the dataset, then sends using the `BUTTONDOWN_API_TOKEN` secret.
- Subscribe forms now target the real Buttondown username `kawacu`; the newsletter page links the canonical live archive.
- Security hardening: markup characters are rejected in string fields (validate.py) and all dataset-derived strings are escaped (app.js); CODEOWNERS pins guard-rail paths.
- Issue 002 was published via the API as a pipeline proof (already live at https://buttondown.com/kawacu/archive/).

## Verify

- [ ] CI validate-data passes
- [ ] Pages deploy shows newsletter pages
- [ ] Newsletter workflow is present