### PR TITLE
chore: add GitHub Sponsors and Open Collective funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [kawacukennedy]
+open_collective: afrpoweros


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the Sponsor button appears on the repo page.

- GitHub Sponsors: kawacukennedy
- Open Collective: afrpoweros