### PR TITLE
feat(site): SEO — per-country pages, sitemap, robots, structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ALU/University of Rwanda fallback.
 - Monetization plan: who to pitch for first $500 report, how to land it,
   revenue projections, and what NOT to do.
+- SEO overhaul: per-country static pages generated at build time (unique
+  title, meta description, canonical, Dataset JSON-LD, key facts, key events,
+  sources and related-country links) targeting long-tail "country + nuclear
+  program" queries; a country index page; homepage FAQ section and FAQPage
+  JSON-LD rich result markup; Open Graph / Twitter card meta; `sitemap.xml`
+  and `robots.txt` emitted by the build; canonical + robots meta injected on
+  newsletter pages; `map-screenshot.png` copied to the deploy root for social
+  share previews.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ Every field carries a confidence label:
 | `Speculation` | Hypothesis; treat as unproven. |
 | `Unverified` | Reported but not yet confirmed. Check before relying. |
 
+## Web site
+
+The static site is generated from the dataset by `scripts/build_site.py`
+(no dependencies, run by CI before deploy):
+
+- **Homepage** (`site/index.html`) — interactive map, country table, FAQ,
+  dataset + FAQPage structured data, Open Graph/Twitter meta.
+- **Per-country pages** — `site/dist/countries/<slug>.html` for all 20
+  countries, each with its own title, meta description, canonical URL,
+  key facts, key events, sources and related-country links (targets
+  long-tail "&lt;country&gt; nuclear program" searches).
+- **Country index** — `site/dist/countries/index.html`.
+- **`sitemap.xml` and `robots.txt`** — emitted into `site/dist/`.
+
+Point Google Search Console at `https://kawacukennedy.github.io/afrpoweros` and
+submit `sitemap.xml` to start indexing the per-country pages.
+
 ## Quick start
 
 ```bash

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -45,6 +45,11 @@ def main():
         shutil.rmtree(DIST)
     (DIST / "data").mkdir(parents=True)
 
+    for static in ("map-screenshot.png",):
+        src = SITE / static
+        if src.exists():
+            shutil.copy2(src, DIST / static)
+
     (DIST / renamed["data/dataset.js"]).write_text(dataset_js, encoding="utf-8")
     shutil.copy2(SITE / "data" / "africa.js", DIST / renamed["data/africa.js"])
     shutil.copy2(SITE / "styles.css", DIST / renamed["styles.css"])
@@ -67,6 +72,7 @@ def main():
         text = text.replace("data/dataset.js?v=__VER__", renamed["data/dataset.js"])
         text = text.replace("data/africa.js?v=__VER__", renamed["data/africa.js"])
         text = text.replace("app.js?v=__VER__", renamed["app.js"])
+        text = _seo_inject(text, f"{BASE_URL}/{rel}")
         dst = DIST / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
         dst.write_text(text, encoding="utf-8")
@@ -74,15 +80,322 @@ def main():
     for src in (SITE / "newsletter").glob("*.html"):
         text = src.read_text(encoding="utf-8")
         text = text.replace("styles.css?v=__VER__", renamed["styles.css"])
+        text = _seo_inject(text, f"{BASE_URL}/newsletter/{src.name}")
         dst = DIST / "newsletter" / src.name
         dst.parent.mkdir(parents=True, exist_ok=True)
         dst.write_text(text, encoding="utf-8")
+
+    _generate_seo(dataset, DIST, renamed["styles.css"])
 
     print(f"build: wrote {DIST} ({n} countries, ver {version})")
     for name in sorted(renamed.values()):
         size = (DIST / name).stat().st_size
         print(f"  {name}  {size} bytes")
     return 0
+
+
+BASE_URL = "https://kawacukennedy.github.io/afrpoweros"
+
+STATUS_DESC = {
+    "Operating": "Operating commercial reactor(s) generating electricity",
+    "Under Construction": "Reactor(s) being built, not yet operational",
+    "Announced": "Government has formally announced nuclear plans",
+    "Preparing": "Infrastructure development before procurement",
+    "Exploring": "Early-stage assessment, no commitment yet",
+    "None": "No known civilian nuclear program",
+}
+
+MILESTONE_DESC = {
+    1: "Ready to make a knowledgeable commitment to nuclear power",
+    2: "Ready to invite bids / negotiate a contract",
+    3: "Ready to operate the first nuclear power plant",
+}
+
+
+def slugify(name):
+    out = []
+    for ch in name.lower():
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in " _&,":
+            out.append("-")
+    s = "".join(out)
+    while "--" in s:
+        s = s.replace("--", "-")
+    return s.strip("-")
+
+
+def esc(text):
+    return (
+        str(text)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def _page_head(title, description, canonical, stylesheet):
+    return (
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
+        "  <meta charset=\"UTF-8\">\n"
+        "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n"
+        f"  <title>{esc(title)}</title>\n"
+        f"  <meta name=\"description\" content=\"{esc(description)}\">\n"
+        f"  <meta name=\"robots\" content=\"index, follow\">\n"
+        f"  <link rel=\"canonical\" href=\"{canonical}\">\n"
+        f"  <meta property=\"og:type\" content=\"website\">\n"
+        f"  <meta property=\"og:site_name\" content=\"AfrPowerOS\">\n"
+        f"  <meta property=\"og:title\" content=\"{esc(title)}\">\n"
+        f"  <meta property=\"og:description\" content=\"{esc(description)}\">\n"
+        f"  <meta property=\"og:url\" content=\"{canonical}\">\n"
+        f"  <meta name=\"twitter:card\" content=\"summary_large_image\">\n"
+        f"  <link rel=\"stylesheet\" href=\"{stylesheet}\">\n"
+    )
+
+
+def _page_shell(title, description, canonical, body, stylesheet, head_extra=""):
+    head = _page_head(title, description, canonical, stylesheet)
+    return (
+        head +
+        head_extra +
+        "</head>\n<body>\n" +
+        body +
+        "  <footer class=\"footer\">\n"
+        "    <p>AfrPowerOS · MIT code · CC BY 4.0 data</p>\n"
+        "    <p><a href=\"https://github.com/kawacukennedy/afrpoweros\">github.com/kawacukennedy/afrpoweros</a> · "
+        "<a href=\"" + BASE_URL + "/\">Dataset</a> · "
+        "<a href=\"" + BASE_URL + "/countries/\">All countries</a></p>\n"
+        "  </footer>\n"
+        "</body>\n</html>\n"
+    )
+
+
+def _nav(active):
+    def item(href, label):
+        return f"<a href=\"{href}\">{label}</a>"
+    links = " ".join([
+        item("/afrpoweros/#map", "Map"),
+        item("/afrpoweros/#table", "Countries"),
+        item("/afrpoweros/#method", "Method"),
+        item("/afrpoweros/newsletter.html", "Newsletter"),
+        item("https://github.com/kawacukennedy/afrpoweros", "GitHub"),
+    ])
+    return (
+        "  <header class=\"nav\">\n"
+        "    <div class=\"nav-inner\">\n"
+        "      <a class=\"brand\" href=\"/afrpoweros/\">\n"
+        "        <span class=\"brand-dot\"></span>\n"
+        "        <span>AfrPowerOS</span>\n"
+        "      </a>\n"
+        "      <nav class=\"nav-links\">\n" + links + "\n      </nav>\n"
+        "    </div>\n"
+        "  </header>\n"
+    )
+
+
+def _seo_inject(html, canonical):
+    meta = (
+        "  <meta name=\"robots\" content=\"index, follow\">\n"
+        + f"  <link rel=\"canonical\" href=\"{canonical}\">\n"
+    )
+    if "rel=\"canonical\"" in html:
+        return html
+    return html.replace("</head>", meta + "</head>", 1)
+
+
+def _country_page(rec, stylesheet):
+    country = rec["country"]
+    slug = slugify(country)
+    status = rec.get("program_status")
+    phase = rec.get("iaea_milestone_phase")
+    desc = (
+        f"{country}'s nuclear power program status: {status} "
+        f"{'(IAEA milestone phase {})'.format(phase) if phase else ''}. "
+        "Confidence-labelled, cited records on capacity, grid targets, regulators, "
+        "vendors and key events, from the open AfrPowerOS dataset."
+    )
+    canonical = f"{BASE_URL}/countries/{slug}.html"
+
+    rows = ""
+    def kv(key, value):
+        nonlocal rows
+        rows += f"<li><span class=\"k\">{esc(key)}</span><span class=\"v\">{value}</span></li>\n"
+
+    kv("Country", esc(country))
+    kv("Region", esc(rec.get("region") or ""))
+    kv("Program status", esc(status or "") + " — " + esc(STATUS_DESC.get(status, "")))
+    if phase:
+        kv("IAEA milestone phase", f"Phase {esc(phase)} — {esc(MILESTONE_DESC.get(phase, ''))}")
+    kv("Commercial reactors operating", esc(rec.get("commercial_reactors_operating") or 0))
+    kv("Commercial reactors under construction", esc(rec.get("commercial_reactors_under_construction") or 0))
+    if rec.get("capacity_gw_planned") is not None:
+        kv("Planned capacity", f"{esc(rec.get('capacity_gw_planned'))} GW")
+    if rec.get("first_grid_target_year"):
+        kv("First grid target", esc(rec.get("first_grid_target_year")))
+    if rec.get("research_reactor"):
+        kv("Research reactor", esc(rec.get("research_reactor")))
+    if rec.get("regulator"):
+        kv("Regulator", esc(rec.get("regulator")))
+    if rec.get("implementing_agency"):
+        kv("Implementing agency", esc(rec.get("implementing_agency")))
+    if rec.get("vendors"):
+        kv("Vendors", ", ".join(esc(v) for v in rec.get("vendors")))
+    if rec.get("agreements"):
+        kv("Agreements", "; ".join(esc(a) for a in rec.get("agreements")))
+    if rec.get("electricity_access_pct") is not None:
+        kv("Electricity access", f"{esc(rec.get('electricity_access_pct'))}%")
+    if rec.get("installed_capacity_mw"):
+        kv("Installed capacity", f"{esc(rec.get('installed_capacity_mw'))} MW")
+    kv("Confidence", esc(rec.get("confidence") or ""))
+    kv("Last verified", esc(rec.get("last_verified") or ""))
+
+    events = ""
+    if rec.get("key_events"):
+        events = "<h2>Key events</h2>\n<ul class=\"event-list\">\n"
+        for ev in rec.get("key_events"):
+            src = ev.get("source", "")
+            link = f" <a href=\"{esc(src)}\" rel=\"noopener\" target=\"_blank\">source</a>" if src else ""
+            events += (
+                f"<li><span class=\"date\">{esc(ev.get('date') or '')}</span>"
+                f"{esc(ev.get('title') or '')}{link}</li>\n"
+            )
+        events += "</ul>\n"
+
+    sources = ""
+    if rec.get("sources"):
+        sources = "<h2>Sources</h2>\n<ul class=\"source-list\">\n"
+        for s in rec.get("sources"):
+            sources += f"<li><a href=\"{esc(s)}\" rel=\"noopener\" target=\"_blank\">{esc(s)}</a></li>\n"
+        sources += "</ul>\n"
+
+    notes = ""
+    if rec.get("notes"):
+        notes = f"<h2>Summary</h2>\n<p>{esc(rec.get('notes'))}</p>\n"
+
+    related = ""
+    if rec.get("region"):
+        related_links = []
+        for other in _ALL_RECS:
+            if other["country"] != country and other.get("region") == rec.get("region"):
+                s2 = slugify(other["country"])
+                related_links.append(
+                    f"<a href=\"{s2}.html\">{esc(other['country'])}</a>"
+                )
+        if related_links:
+            related = (
+                "<h2>Related countries</h2>\n<p>"
+                + ", ".join(related_links[:6])
+                + "</p>\n"
+            )
+
+    ld = {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "name": f"AfrPowerOS — {country} nuclear program",
+        "description": desc,
+        "url": canonical,
+        "license": "https://creativecommons.org/licenses/by/4.0/",
+        "isAccessibleForFree": True,
+    }
+    ld_html = json.dumps(ld, ensure_ascii=False)
+
+    body = (
+        _nav(country) +
+        "  <main>\n"
+        "    <div class=\"breadcrumb\"><a href=\"/afrpoweros/\">Home</a> &rsaquo; "
+        "<a href=\"index.html\">Countries</a> &rsaquo; " + esc(country) + "</div>\n"
+        "    <section class=\"country-hero\">\n"
+        "      <p class=\"eyebrow\">AfrPowerOS country record</p>\n"
+        "<h1>" + esc(country) + "'s nuclear &amp; energy program</h1>\n"
+        "      <p class=\"hero-sub\">" + esc(desc) + "</p>\n"
+        "    </section>\n"
+        "    <section class=\"country-body\">\n"
+        "      <div class=\"country-card\">\n"
+        "<h2>" + esc(country) + " — key facts</h2>\n"
+        "        <ul class=\"kv-list\">\n" + rows + "        </ul>\n"
+        + notes + events + sources + related +
+        "        <p class=\"confidence-note\">Confidence labels: Verified (primary source), "
+        "Inference (reasonable reading of verified evidence), Speculation (hypothesis), "
+        "Unverified (reported, not confirmed). See the "
+        "<a href=\"https://github.com/kawacukennedy/afrpoweros/blob/main/docs/methodology.md\">methodology</a>.</p>\n"
+        "      </div>\n"
+        "    </section>\n"
+        "  </main>\n"
+    )
+    head_extra = (
+        "  <script type=\"application/ld+json\">" + ld_html + "</script>\n"
+    )
+    return _page_shell(
+        f"{country} Nuclear Program Status | AfrPowerOS", desc, canonical, body,
+        stylesheet, head_extra=head_extra,
+    ), slug
+
+
+def _countries_index(recs, stylesheet):
+    desc = (
+        "Dedicated pages for every African country with a civilian nuclear program: "
+        "status, IAEA milestone phase, capacity, grid targets, regulators and cited sources — "
+        "open and machine-readable from AfrPowerOS."
+    )
+    canonical = f"{BASE_URL}/countries/index.html"
+    items = ""
+    for rec in sorted(recs, key=lambda r: r["country"]):
+        slug = slugify(rec["country"])
+        items += (
+            f"<li class=\"country-link\"><a href=\"{slug}.html\">"
+            f"{esc(rec['country'])} — {esc(rec.get('program_status') or '')}"
+            f"</a></li>\n"
+        )
+    body = (
+        _nav("countries") +
+        "  <main>\n"
+        "    <div class=\"breadcrumb\"><a href=\"/afrpoweros/\">Home</a> &rsaquo; Countries</div>\n"
+        "    <section class=\"country-hero\">\n"
+        "      <p class=\"eyebrow\">AfrPowerOS country index</p>\n"
+        "<h1>African countries with nuclear energy programs</h1>\n"
+        "      <p class=\"hero-sub\">" + esc(desc) + "</p>\n"
+        "    </section>\n"
+        "    <section class=\"country-body\">\n"
+        "      <div class=\"country-card\">\n"
+        "        <ul class=\"kv-list country-index-list\">\n" + items + "        </ul>\n"
+        "      </div>\n"
+        "    </section>\n"
+        "  </main>\n"
+    )
+    return _page_shell("African Countries With Nuclear Energy Programs | AfrPowerOS", desc, canonical, body, stylesheet)
+
+
+def _generate_seo(dataset, dist, stylesheet):
+    global _ALL_RECS
+    _ALL_RECS = dataset["countries"]
+    dist = Path(dist)
+    (dist / "countries").mkdir(parents=True, exist_ok=True)
+
+    urls = [f"{BASE_URL}/"]
+    urls.append(f"{BASE_URL}/countries/index.html")
+
+    pages = []
+    nested_stylesheet = "../" + stylesheet
+    for rec in _ALL_RECS:
+        html, slug = _country_page(rec, nested_stylesheet)
+        (dist / "countries" / f"{slug}.html").write_text(html, encoding="utf-8")
+        urls.append(f"{BASE_URL}/countries/{slug}.html")
+    pages.append(_countries_index(_ALL_RECS, nested_stylesheet))
+    (dist / "countries" / "index.html").write_text(pages[0], encoding="utf-8")
+
+    sitemap = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + "".join(f"  <url><loc>{u}</loc></url>\n" for u in urls)
+        + "</urlset>\n"
+    )
+    (dist / "sitemap.xml").write_text(sitemap, encoding="utf-8")
+    (dist / "robots.txt").write_text(
+        "User-agent: *\nAllow: /\nSitemap: " + BASE_URL + "/sitemap.xml\n",
+        encoding="utf-8",
+    )
+    print(f"seo: wrote {len(urls)} urls, {len(_ALL_RECS)} country pages, sitemap.xml, robots.txt")
 
 
 if __name__ == "__main__":

--- a/site/index.html
+++ b/site/index.html
@@ -3,9 +3,80 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AfrPowerOS — African Nuclear &amp; Energy Infrastructure</title>
-  <meta name="description" content="Open, cited intelligence on civilian African nuclear and energy infrastructure programs.">
+  <title>African Nuclear Power Programs — Status, Timeline &amp; Sources for 20 Countries | AfrPowerOS</title>
+  <meta name="description" content="Open, cited dataset tracking every African country's civilian nuclear energy program: operating, under construction, preparing, exploring or none. Confidence-labelled records, IAEA milestone phases, grid targets, regulators and sources.">
+  <meta name="keywords" content="African nuclear power, nuclear energy Africa, Africa nuclear program, nuclear power plants Africa, Egypt nuclear, South Africa nuclear, Kenya nuclear, IAEA milestones Africa">
+  <meta name="author" content="AfrPowerOS">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://kawacukennedy.github.io/afrpoweros/">
+  <link rel="sitemap" type="application/xml" href="https://kawacukennedy.github.io/afrpoweros/sitemap.xml">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="AfrPowerOS">
+  <meta property="og:title" content="AfrPowerOS — African Nuclear &amp; Energy Infrastructure, mapped">
+  <meta property="og:description" content="Open, cited data on every African country's civilian nuclear program. Free, machine-readable, confidence-labelled.">
+  <meta property="og:url" content="https://kawacukennedy.github.io/afrpoweros/">
+  <meta property="og:image" content="https://kawacukennedy.github.io/afrpoweros/map-screenshot.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="AfrPowerOS — African Nuclear &amp; Energy Infrastructure">
+  <meta name="twitter:description" content="Open, cited data on every African country's civilian nuclear program.">
+  <meta name="twitter:image" content="https://kawacukennedy.github.io/afrpoweros/map-screenshot.png">
   <link rel="stylesheet" href="styles.css?v=__VER__">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "name": "AfrPowerOS — African Nuclear & Energy Infrastructure",
+    "description": "Open, cited dataset tracking every African country's civilian nuclear energy program with confidence labels, IAEA milestone phases, grid targets, regulators, vendors and sources.",
+    "url": "https://kawacukennedy.github.io/afrpoweros/",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "isAccessibleForFree": true,
+    "includedInDataCatalog": { "@type": "DataCatalog", "name": "AfrPowerOS" },
+    "creator": {
+      "@type": "Organization",
+      "name": "AfrPowerOS"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Which African countries are operating nuclear power plants?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "As of the latest AfrPowerOS record, South Africa is the only African country with operating commercial nuclear reactors."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which African countries are building nuclear power plants?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Egypt is the only African country with commercial reactors under construction (El Dabaa), while several others are in the preparing or exploring phase."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How many African countries have nuclear energy programs?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "AfrPowerOS tracks 20 African countries; the majority have active civilian nuclear programs in the exploring, preparing or construction phase, with South Africa operating and Egypt under construction."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is the IAEA Milestones approach for nuclear power?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The IAEA Milestones approach guides countries through three phases of nuclear power infrastructure development: ready to make a knowledgeable commitment, ready to invite bids or negotiate a contract, and ready to operate the first plant."
+        }
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <header class="nav">
@@ -105,6 +176,57 @@
           <input type="email" name="email" placeholder="you@example.com" required>
           <button type="submit" class="btn btn-primary">Subscribe free</button>
         </form>
+      </div>
+    </section>
+
+    <section class="country-links" id="countries">
+      <h2>Country records</h2>
+      <p class="country-links-sub">Dedicated pages for every African country tracked, each with cited sources and confidence labels.</p>
+      <ul class="country-link-grid">
+        <li><a href="countries/egypt.html">Egypt nuclear program</a></li>
+        <li><a href="countries/south-africa.html">South Africa nuclear program</a></li>
+        <li><a href="countries/kenya.html">Kenya nuclear program</a></li>
+        <li><a href="countries/ghana.html">Ghana nuclear program</a></li>
+        <li><a href="countries/nigeria.html">Nigeria nuclear program</a></li>
+        <li><a href="countries/rwanda.html">Rwanda nuclear program</a></li>
+        <li><a href="countries/uganda.html">Uganda nuclear program</a></li>
+        <li><a href="countries/tanzania.html">Tanzania nuclear program</a></li>
+        <li><a href="countries/sudan.html">Sudan nuclear program</a></li>
+        <li><a href="countries/zambia.html">Zambia nuclear program</a></li>
+        <li><a href="countries/morocco.html">Morocco nuclear program</a></li>
+        <li><a href="countries/algeria.html">Algeria nuclear program</a></li>
+        <li><a href="countries/ethiopia.html">Ethiopia nuclear program</a></li>
+        <li><a href="countries/tunisia.html">Tunisia nuclear program</a></li>
+        <li><a href="countries/zimbabwe.html">Zimbabwe nuclear program</a></li>
+        <li><a href="countries/senegal.html">Senegal nuclear program</a></li>
+        <li><a href="countries/mali.html">Mali nuclear program</a></li>
+        <li><a href="countries/niger.html">Niger nuclear program</a></li>
+        <li><a href="countries/eswatini.html">Eswatini nuclear program</a></li>
+        <li><a href="countries/dr-congo.html">DR Congo nuclear program</a></li>
+      </ul>
+    </section>
+
+    <section class="faq" id="faq">
+      <h2>Frequently asked questions</h2>
+      <div class="faq-item">
+        <h3>Which African countries are operating nuclear power plants?</h3>
+        <p>As of the latest AfrPowerOS record, <strong>South Africa</strong> is the only African country with operating commercial nuclear reactors.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Which African countries are building nuclear power plants?</h3>
+        <p><strong>Egypt</strong> is the only African country with commercial reactors under construction (the El Dabaa plant), while several others are in the preparing or exploring phase of the IAEA Milestones approach.</p>
+      </div>
+      <div class="faq-item">
+        <h3>How many African countries have nuclear energy programs?</h3>
+        <p>AfrPowerOS tracks <strong>20 African countries</strong>. Of these, the large majority have active civilian nuclear programs: one operating (South Africa), one under construction (Egypt), and the rest preparing or exploring. Every record is cited and confidence-labelled.</p>
+      </div>
+      <div class="faq-item">
+        <h3>What is the IAEA Milestones approach?</h3>
+        <p>The IAEA Milestones approach guides a country through three phases of nuclear infrastructure development: ready to make a knowledgeable commitment (Phase 1), ready to invite bids or negotiate a contract (Phase 2), and ready to operate the first plant (Phase 3).</p>
+      </div>
+      <div class="faq-item">
+        <h3>How is AfrPowerOS different from other nuclear trackers?</h3>
+        <p>Every record in AfrPowerOS carries a source link and a confidence label (Verified, Inference, Speculation, or Unverified). Nothing is invented — if a fact can't be verified it is marked Unverified or omitted. The full dataset is free and machine-readable.</p>
       </div>
     </section>
   </main>

--- a/site/newsletter.html
+++ b/site/newsletter.html
@@ -42,6 +42,7 @@
     <section class="card newsletter-archive">
       <h2>Past issues</h2>
       <ul class="archive-list">
+        <li><a href="newsletter/issue-003.html">Issue 003 — Kenya triples nuclear target, Egypt plans expansion, US-Africa summit delivers</a> <span class="newsletter-date">· 2026-08-24</span></li>
         <li><a href="newsletter/issue-002.html">Issue 002 — AfrPowerOS Weekly · 20 countries, 20 verified · 2026-08-16</a> <span class="newsletter-date">· 2026-08-16</span></li>
         <li><a href="newsletter/issue-001.html">Issue 001 — Why I'm building a sourced tracker for Africa's nuclear plans</a></li>
       </ul>

--- a/site/styles.css
+++ b/site/styles.css
@@ -511,6 +511,223 @@ tbody tr.highlight { animation: flash 2s ease; }
   thead th:nth-child(8), tbody td:nth-child(8) { display: none; }
 }
 
+/* SEO: country link grid + FAQ */
+.country-links {
+  max-width: 900px;
+  margin: 0 auto 80px;
+}
+
+.country-links h2 {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.country-links-sub {
+  text-align: center;
+  color: var(--text-2);
+  font-size: 15px;
+  margin-bottom: 24px;
+}
+
+.country-link-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.country-link-grid a {
+  display: block;
+  padding: 12px 16px;
+  background: var(--card);
+  border-radius: 14px;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 14px;
+  border: 1px solid var(--line);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.country-link-grid a:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+  color: var(--pr);
+}
+
+.faq {
+  max-width: 760px;
+  margin: 0 auto 80px;
+}
+
+.faq h2 {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 22px;
+  text-align: center;
+}
+
+.faq-item {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 22px 26px;
+  margin-bottom: 12px;
+}
+
+.faq-item h3 {
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.faq-item p {
+  color: var(--text-2);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.faq-item a { color: var(--pr); text-decoration: none; }
+
+/* SEO: static country pages */
+.country-hero {
+  text-align: center;
+  padding: 56px 0 24px;
+}
+
+.country-hero .eyebrow { margin-bottom: 10px; }
+
+.country-hero h1 {
+  font-size: clamp(30px, 5vw, 46px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin-bottom: 14px;
+}
+
+.country-hero .hero-sub {
+  max-width: 640px;
+  font-size: 16px;
+}
+
+.breadcrumb {
+  max-width: 760px;
+  margin: 0 auto;
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+.breadcrumb a {
+  color: var(--pr);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover { text-decoration: underline; }
+
+.country-body {
+  max-width: 760px;
+  margin: 0 auto 80px;
+}
+
+.country-card {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 32px 36px;
+  margin-bottom: 24px;
+}
+
+.country-card h2 {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 26px 0 12px;
+}
+
+.country-card h2:first-child { margin-top: 0; }
+
+.country-card p {
+  color: var(--text-2);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.kv-list {
+  list-style: none;
+  margin: 0;
+}
+
+.kv-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 14px;
+}
+
+.kv-list li:last-child { border-bottom: none; }
+
+.kv-list .k {
+  color: var(--text-2);
+  flex-shrink: 0;
+}
+
+.kv-list .v { font-weight: 500; text-align: right; }
+
+.kv-list .v a { color: var(--pr); text-decoration: none; }
+
+.event-list {
+  list-style: none;
+  margin: 0;
+}
+
+.event-list li {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.event-list li:last-child { border-bottom: none; }
+
+.event-list .date {
+  display: inline-block;
+  min-width: 88px;
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.source-list { list-style: none; margin: 0; }
+
+.source-list li {
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+
+.source-list a {
+  color: var(--pr);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.source-list a:hover { text-decoration: underline; }
+
+.confidence-note {
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+@media (max-width: 720px) {
+  .country-card { padding: 22px 18px; }
+  .kv-list li { flex-direction: column; gap: 2px; }
+  .kv-list .v { text-align: left; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   * { transition: none !important; animation: none !important; }


### PR DESCRIPTION
## What

SEO overhaul of the static site so it can rank for long-tail African-energy searches:

- **20 per-country static pages** (`site/dist/countries/<slug>.html`) generated at build time, each with a unique title, meta description, canonical URL, Dataset JSON-LD, key facts, key events, sources and related-country links. Targets query intent like "Egypt nuclear power plant status" / "Kenya nuclear program".
- **Country index** at `/countries/index.html`.
- **Homepage**: richer title/meta, canonical, sitemap link, Open Graph + Twitter card tags, JSON-LD (Dataset + FAQPage), a visible FAQ section, and a crawlable country-links grid.
- **`sitemap.xml` + `robots.txt`** emitted into `site/dist/`.
- **Canonical/robots meta** auto-injected on newsletter pages.
- `map-screenshot.png` copied into the deploy root for social share previews.

Docs: README section on the web site; CHANGELOG entry.

## Verification

- `python3 scripts/build_site.py` runs clean (20 countries, 22 URLs).
- `python3 scripts/validate.py` → all checks pass.
- Inspected generated pages: canonical URLs, JSON-LD, internal links, stylesheet paths (`../styles.*.css`) all correct.