### PR TITLE
feat: assertion-level confidence labels (countries 1–5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `robots.txt` emitted by the build; canonical + robots meta injected on
   newsletter pages; `map-screenshot.png` copied to the deploy root for social
   share previews.
+- Per-assertion sourcing and confidence labels: `data/assertions-schema.json`
+  defines a claim-level structure (field, value, confidence, source_url,
+  observation_date, verification_date) that replaces the single country-wide
+  confidence label; `data/schema.json` gained an optional `assertions` array.
+  `scripts/validate.py` validates every assertion; `scripts/build_site.py`
+  renders a per-country "Claims and confidence labels" table. Backfilled for
+  Rwanda, South Africa, Egypt, Nigeria and Kenya, with homepage-level sources
+  replaced by precise article URLs (e.g. IAEA INIR press release, World
+  Nuclear News IRP 2025 coverage) and outdated values corrected to latest
+  verified figures (South Africa IRP 2025 5,200 MW / 2039, Kenya Siaya 2,000
+  MW target).

--- a/data/afrpoweros.json
+++ b/data/afrpoweros.json
@@ -14,12 +14,15 @@
       "research_reactor": null,
       "regulator": "Rwanda Atomic Energy Board (RAEB)",
       "implementing_agency": "Rwanda Atomic Energy Board (RAEB) / Ministry of Infrastructure (MININFRA)",
-      "vendors": ["Dual Fluid Energy", "Rosatom"],
+      "vendors": [
+        "Dual Fluid Energy",
+        "Rosatom"
+      ],
       "agreements": [
         "Russia-Rwanda agreement on nuclear energy cooperation (2025)",
         "Rwanda-Dual Fluid Energy agreement (2024)"
       ],
-      "electricity_access_pct": 70.0,
+      "electricity_access_pct": 75.0,
       "installed_capacity_mw": null,
       "notes": "Advanced the furthest of the IAEA Phase 2 countries in East Africa. Completed IAEA INIR Phase 2 review with a follow-up mission (March 2026). Signed a phased roadmap with Russia (2025) targeting an initial nuclear phase by ~2030 and a first-of-kind Dual Fluid Energy reactor feasibility study due ~June 2026. No procurement decision made.",
       "key_events": [
@@ -52,7 +55,87 @@
         "https://www.reg.rw"
       ],
       "confidence": "Verified",
-      "last_verified": "2026-08-16"
+      "last_verified": "2026-08-16",
+      "assertions": [
+        {
+          "field": "program_status",
+          "value": "Preparing",
+          "confidence": "Verified",
+          "source_url": "https://www.iaea.org/newscenter/pressreleases/iaea-reviews-rwandas-nuclear-power-infrastructure-development",
+          "observation_date": "2026-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "iaea_milestone_phase",
+          "value": 2,
+          "confidence": "Verified",
+          "source_url": "https://www.iaea.org/newscenter/pressreleases/iaea-reviews-rwandas-nuclear-power-infrastructure-development",
+          "observation_date": "2026-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_operating",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://www.iaea.org/newscenter/pressreleases/iaea-reviews-rwandas-nuclear-power-infrastructure-development",
+          "observation_date": "2026-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_under_construction",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://www.iaea.org/newscenter/pressreleases/iaea-reviews-rwandas-nuclear-power-infrastructure-development",
+          "observation_date": "2026-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "first_grid_target_year",
+          "value": 2030,
+          "confidence": "Inference",
+          "source_url": "https://world-nuclear-news.org/articles/russia-and-rwanda-hold-first-nuclear-energy-joint-committee-meeting",
+          "observation_date": "2026-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "vendors",
+          "value": [
+            "Dual Fluid Energy",
+            "Rosatom"
+          ],
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/demonstration-reactor-to-be-built-in-rwanda",
+          "observation_date": "2023-09",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "agreements",
+          "value": [
+            "Russia-Rwanda agreement on nuclear energy cooperation (2025)",
+            "Rwanda-Dual Fluid Energy agreement (2024)"
+          ],
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/russia-and-rwanda-hold-first-nuclear-energy-joint-committee-meeting",
+          "observation_date": "2026-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "electricity_access_pct",
+          "value": 75.0,
+          "confidence": "Verified",
+          "source_url": "https://www.worldbank.org/en/news/feature/2024/04/10/ingredients-for-accelerating-universal-electricity-access-lessons-from-afe-rwanda-inspirational-approach",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "installed_capacity_mw",
+          "value": null,
+          "confidence": "Verified",
+          "source_url": "https://www.iaea.org/newscenter/pressreleases/iaea-reviews-rwandas-nuclear-power-infrastructure-development",
+          "observation_date": "2026-03",
+          "verification_date": "2026-08-16"
+        }
+      ]
     },
     {
       "country": "Kenya",
@@ -61,7 +144,7 @@
       "iaea_milestone_phase": 2,
       "commercial_reactors_operating": 0,
       "commercial_reactors_under_construction": 0,
-      "capacity_gw_planned": 1.0,
+      "capacity_gw_planned": 2.0,
       "first_grid_target_year": 2034,
       "research_reactor": null,
       "regulator": "Kenya Nuclear Regulatory Authority (KNRA)",
@@ -96,7 +179,67 @@
         "https://nuclear.go.ke"
       ],
       "confidence": "Verified",
-      "last_verified": "2026-08-16"
+      "last_verified": "2026-08-16",
+      "assertions": [
+        {
+          "field": "program_status",
+          "value": "Preparing",
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/kenya-agency-outlines-nuclear-development-plans",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "iaea_milestone_phase",
+          "value": 2,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/kenya-agency-outlines-nuclear-development-plans",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_operating",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/kenya-agency-outlines-nuclear-development-plans",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_under_construction",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/kenya-agency-outlines-nuclear-development-plans",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "capacity_gw_planned",
+          "value": 2.0,
+          "confidence": "Unverified",
+          "source_url": "https://www.kenyanews.net/news/278943804/intl-nuclear-energy-forum-opens-in-kenya-amid-call-for-safety",
+          "observation_date": "2026-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "first_grid_target_year",
+          "value": 2034,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/kenya-agency-outlines-nuclear-development-plans",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "agreements",
+          "value": [
+            "Bilateral nuclear cooperation agreements with IAEA, United States, South Korea, China and Russia"
+          ],
+          "confidence": "Unverified",
+          "source_url": "https://world-nuclear-news.org/articles/kenya-agency-outlines-nuclear-development-plans",
+          "observation_date": "2024-03",
+          "verification_date": "2026-08-16"
+        }
+      ]
     },
     {
       "country": "Ghana",
@@ -110,7 +253,14 @@
       "research_reactor": "GHARR-1 (30 kW miniature neutron source reactor)",
       "regulator": "Nuclear Regulatory Authority (NRA)",
       "implementing_agency": "Nuclear Power Ghana (NPG) / Ghana Atomic Energy Commission (GAEC)",
-      "vendors": ["EDF (France)", "NuScale / GE-Hitachi / Regnum (United States)", "KEPCO/KHNP (South Korea)", "CNNC/CGN (China)", "Rosatom (Russia)", "Laurentis Energy Partners / Ontario Power Generation (Canada)"],
+      "vendors": [
+        "EDF (France)",
+        "NuScale / GE-Hitachi / Regnum (United States)",
+        "KEPCO/KHNP (South Korea)",
+        "CNNC/CGN (China)",
+        "Rosatom (Russia)",
+        "Laurentis Energy Partners / Ontario Power Generation (Canada)"
+      ],
       "agreements": [
         "Vendor EOI finalists announced (March 2025) pending selection",
         "IAEA Integrated Nuclear Infrastructure Review support"
@@ -155,7 +305,9 @@
       "research_reactor": "ETRR-1 (2 MW) and ETRR-2 (22 MW)",
       "regulator": "Egyptian Nuclear and Radiological Regulatory Authority (ENRRA)",
       "implementing_agency": "Nuclear Power Plants Authority (NPPA)",
-      "vendors": ["Rosatom"],
+      "vendors": [
+        "Rosatom"
+      ],
       "agreements": [
         "Russia-Egypt intergovernmental agreement (2015)",
         "Russian state loan facility (~USD 25 billion)"
@@ -181,7 +333,86 @@
         "https://www.nppa.gov.eg"
       ],
       "confidence": "Verified",
-      "last_verified": "2026-08-16"
+      "last_verified": "2026-08-16",
+      "assertions": [
+        {
+          "field": "program_status",
+          "value": "Under Construction",
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/construction-of-egypts-first-nuclear-power-plant-u",
+          "observation_date": "2022-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "iaea_milestone_phase",
+          "value": 3,
+          "confidence": "Inference",
+          "source_url": "https://world-nuclear.org/Information-Library/Country-Profiles/countries-A-F/Egypt",
+          "observation_date": "2026",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_operating",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/construction-of-egypts-first-nuclear-power-plant-u",
+          "observation_date": "2022-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_under_construction",
+          "value": 4,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear-news.org/articles/supplementary-agreements-signed-for-el-dabaa-project",
+          "observation_date": "2025-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "capacity_gw_planned",
+          "value": 4.8,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear.org/news-and-media/press-statements/start-of-construction-of-egypt-s-first-nuclear-pow",
+          "observation_date": "2022-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "first_grid_target_year",
+          "value": 2028,
+          "confidence": "Verified",
+          "source_url": "https://tass.com/economy/2177563",
+          "observation_date": "2026-08",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "research_reactor",
+          "value": "ETRR-1 (2 MW) and ETRR-2 (22 MW)",
+          "confidence": "Inference",
+          "source_url": "https://world-nuclear.org/Information-Library/Country-Profiles/countries-A-F/Egypt",
+          "observation_date": "2026",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "vendors",
+          "value": [
+            "Rosatom"
+          ],
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/construction-of-egypts-first-nuclear-power-plant-u",
+          "observation_date": "2022-07",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "agreements",
+          "value": [
+            "Russia-Egypt intergovernmental agreement (2015)",
+            "Russian state loan facility (~USD 25 billion)"
+          ],
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/el-dabaa-export-loan-ratified-as-unit-4s-core-catcher-installed",
+          "observation_date": "2015-11",
+          "verification_date": "2026-08-16"
+        }
+      ]
     },
     {
       "country": "South Africa",
@@ -190,8 +421,8 @@
       "iaea_milestone_phase": 3,
       "commercial_reactors_operating": 2,
       "commercial_reactors_under_construction": 0,
-      "capacity_gw_planned": 2.5,
-      "first_grid_target_year": 2032,
+      "capacity_gw_planned": 5.2,
+      "first_grid_target_year": 2036,
       "research_reactor": "SAFARI-1 (20 MW tank-in-pool)",
       "regulator": "National Nuclear Regulator (NNR)",
       "implementing_agency": "Eskom (Koeberg) / Department of Mineral and Petroleum Resources / NNEECC",
@@ -202,17 +433,17 @@
       ],
       "electricity_access_pct": 92.0,
       "installed_capacity_mw": 47000.0,
-      "notes": "Only African country with an operating commercial nuclear power plant (Koeberg Units 1 & 2, 1,860 MW net total). The 2032 grid target refers to IRP 2025's plan for 2,500 MW of *new* nuclear capacity — separate from existing Koeberg operations. Unit 2 licence extended to 2044 (May 2025). Strong SME base and PBMR legacy. Procurement route for new build not yet finalised.",
+      "notes": "Only African country with an operating commercial nuclear power plant (Koeberg Units 1 & 2, 1,860 MW net total). IRP 2025 (approved Oct 2025) calls for 5,200 MW of *new* nuclear capacity by 2039, with an initial 1,200 MW targeted for 2036. Koeberg Unit 2 licence extended to 2045 (Nov 2025). Strong SME base and PBMR legacy. Procurement route for new build not yet finalised.",
       "key_events": [
         {
-          "date": "2025-05",
-          "title": "Koeberg Unit 2 operating licence extended to 2044",
-          "source": "https://www.world-nuclear-news.org"
+          "date": "2025-11",
+          "title": "Koeberg Unit 2 operating licence extended to 2045",
+          "source": "https://www.world-nuclear-news.org/articles/koeberg-unit-2-approved-for-extended-operation"
         },
         {
-          "date": "2025-09",
-          "title": "South Africa publishes IRP 2025 with 2,500 MW new nuclear by 2032",
-          "source": "https://www.world-nuclear-news.org"
+          "date": "2025-10",
+          "title": "South Africa approves IRP 2025: 5,200 MW new nuclear by 2039",
+          "source": "https://www.world-nuclear-news.org/articles/south-african-government-approves-draft-2025-irp"
         },
         {
           "date": "2025",
@@ -227,7 +458,75 @@
         "https://www.iaea.org"
       ],
       "confidence": "Verified",
-      "last_verified": "2026-08-16"
+      "last_verified": "2026-08-16",
+      "assertions": [
+        {
+          "field": "program_status",
+          "value": "Operating",
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/koeberg-unit-2-approved-for-extended-operation",
+          "observation_date": "2025-11",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "iaea_milestone_phase",
+          "value": 3,
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/koeberg-unit-2-approved-for-extended-operation",
+          "observation_date": "2025-11",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_operating",
+          "value": 2,
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/koeberg-unit-2-approved-for-extended-operation",
+          "observation_date": "2025-11",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_under_construction",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/koeberg-unit-2-approved-for-extended-operation",
+          "observation_date": "2025-11",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "capacity_gw_planned",
+          "value": 5.2,
+          "confidence": "Verified",
+          "source_url": "https://www.world-nuclear-news.org/articles/south-african-government-approves-draft-2025-irp",
+          "observation_date": "2025-10",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "first_grid_target_year",
+          "value": 2036,
+          "confidence": "Inference",
+          "source_url": "https://www.world-nuclear-news.org/articles/south-african-government-approves-draft-2025-irp",
+          "observation_date": "2025-10",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "research_reactor",
+          "value": "SAFARI-1 (20 MW tank-in-pool)",
+          "confidence": "Verified",
+          "source_url": "https://www.necsa.co.za/safari-1/",
+          "observation_date": "2025",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "agreements",
+          "value": [
+            "US-South Africa 123 Agreement"
+          ],
+          "confidence": "Verified",
+          "source_url": "https://www.energy.gov/sites/default/files/pi_iec/098b7ef980004373.pdf",
+          "observation_date": "1995-08",
+          "verification_date": "2026-08-16"
+        }
+      ]
     },
     {
       "country": "Uganda",
@@ -351,7 +650,67 @@
         "https://www.nnra.gov.ng"
       ],
       "confidence": "Verified",
-      "last_verified": "2026-08-16"
+      "last_verified": "2026-08-16",
+      "assertions": [
+        {
+          "field": "program_status",
+          "value": "Preparing",
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear.org/our-association/publications/world-nuclear-outlook-report/nigeria---world-nuclear-outlook-report",
+          "observation_date": "2025",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "iaea_milestone_phase",
+          "value": 2,
+          "confidence": "Verified",
+          "source_url": "https://nucleus.iaea.org/sites/INPRO/df23/day2-MS/Nigeria.pdf",
+          "observation_date": "2023",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_operating",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear.org/our-association/publications/world-nuclear-outlook-report/nigeria---world-nuclear-outlook-report",
+          "observation_date": "2025",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "commercial_reactors_under_construction",
+          "value": 0,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear.org/our-association/publications/world-nuclear-outlook-report/nigeria---world-nuclear-outlook-report",
+          "observation_date": "2025",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "capacity_gw_planned",
+          "value": 4.0,
+          "confidence": "Verified",
+          "source_url": "https://world-nuclear.org/our-association/publications/world-nuclear-outlook-report/nigeria---world-nuclear-outlook-report",
+          "observation_date": "2025",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "research_reactor",
+          "value": "NIRR-1 (miniature neutron source reactor)",
+          "confidence": "Verified",
+          "source_url": "https://nucleus.iaea.org/sites/INPRO/df23/day2-MS/Nigeria.pdf",
+          "observation_date": "2023",
+          "verification_date": "2026-08-16"
+        },
+        {
+          "field": "agreements",
+          "value": [
+            "China-Nigeria nuclear cooperation MoU (2024)"
+          ],
+          "confidence": "Verified",
+          "source_url": "https://nigatom.gov.ng/nigeria-signs-mou-on-nuclear-energy-with-china/",
+          "observation_date": "2024-09",
+          "verification_date": "2026-08-16"
+        }
+      ]
     },
     {
       "country": "Zambia",
@@ -429,7 +788,9 @@
       "research_reactor": "NUR (1 MW pool) and Es-Salam (15 MW heavy-water)",
       "regulator": "Commissariat à l'Énergie Atomique (COMENA)",
       "implementing_agency": "Commissariat à l'Énergie Atomique (COMENA)",
-      "vendors": ["Rosatom (SMR feasibility discussions)"],
+      "vendors": [
+        "Rosatom (SMR feasibility discussions)"
+      ],
       "agreements": [
         "IAEA country programme framework"
       ],
@@ -588,7 +949,9 @@
       "research_reactor": null,
       "regulator": "Radiation Protection Authority of Zimbabwe (RPAZ)",
       "implementing_agency": "Ministry of Energy and Power Development",
-      "vendors": ["KHNP (i-SMR evaluation MoU)"],
+      "vendors": [
+        "KHNP (i-SMR evaluation MoU)"
+      ],
       "agreements": [
         "Zimbabwe-KHNP MoU on i-SMR deployment evaluation (2025)"
       ],

--- a/data/assertions-schema.json
+++ b/data/assertions-schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AfrPowerOS assertion-level confidence labels",
+  "description": "Per-claim sourcing and confidence for a single country record. Each material factual claim gets its own source, confidence, and date fields.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "required": ["field", "value", "confidence", "source_url", "observation_date", "verification_date"],
+    "additionalProperties": false,
+    "properties": {
+      "field": {
+        "type": "string",
+        "description": "The record field this assertion covers, e.g. 'program_status', 'iaea_milestone_phase', 'vendors'"
+      },
+      "value": {
+        "description": "The asserted value. String, number, integer, array of strings, or null."
+      },
+      "confidence": {
+        "type": "string",
+        "enum": ["Verified", "Inference", "Speculation", "Unverified"]
+      },
+      "source_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Precise article or document URL supporting this assertion (not a homepage)"
+      },
+      "observation_date": {
+        "type": "string",
+        "pattern": "^\\d{4}(-\\d{2})?$",
+        "description": "Date the assertion was observed or recorded (YYYY or YYYY-MM)"
+      },
+      "verification_date": {
+        "type": "string",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "description": "Date this assertion was last independently verified (YYYY-MM-DD)"
+      }
+    }
+  }
+}

--- a/data/countries.csv
+++ b/data/countries.csv
@@ -1,21 +1,21 @@
 country,region,program_status,iaea_milestone_phase,capacity_gw_planned,first_grid_target_year,regulator,implementing_agency,research_reactor,confidence,last_verified
-Rwanda,East Africa,Preparing,2,,2030,Rwanda Atomic Energy Board (RAEB),"Rwanda Atomic Energy Board (RAEB) / Ministry of Infrastructure (MININFRA)",,Verified,2026-08-16
-Kenya,East Africa,Preparing,2,1.0,2034,Kenya Nuclear Regulatory Authority (KNRA),Nuclear Power and Energy Agency (NuPEA),,Verified,2026-08-16
-Ghana,West Africa,Preparing,2,1.0,2030,Nuclear Regulatory Authority (NRA),"Nuclear Power Ghana (NPG) / Ghana Atomic Energy Commission (GAEC)",GHARR-1,Verified,2026-08-16
-Egypt,North Africa,Under Construction,3,4.8,2028,Egyptian Nuclear and Radiological Regulatory Authority (ENRRA),Nuclear Power Plants Authority (NPPA),"ETRR-1 / ETRR-2",Verified,2026-08-16
-South Africa,Southern Africa,Operating,3,2.5,2032,National Nuclear Regulator (NNR),"Eskom (Koeberg) / Department of Mineral and Petroleum Resources / NNEECC",SAFARI-1,Verified,2026-08-16
+Rwanda,East Africa,Preparing,2,,2030,Rwanda Atomic Energy Board (RAEB),Rwanda Atomic Energy Board (RAEB) / Ministry of Infrastructure (MININFRA),,Verified,2026-08-16
+Kenya,East Africa,Preparing,2,2.0,2034,Kenya Nuclear Regulatory Authority (KNRA),Nuclear Power and Energy Agency (NuPEA),,Verified,2026-08-16
+Ghana,West Africa,Preparing,2,1.0,2030,Nuclear Regulatory Authority (NRA),Nuclear Power Ghana (NPG) / Ghana Atomic Energy Commission (GAEC),GHARR-1,Verified,2026-08-16
+Egypt,North Africa,Under Construction,3,4.8,2028,Egyptian Nuclear and Radiological Regulatory Authority (ENRRA),Nuclear Power Plants Authority (NPPA),ETRR-1 / ETRR-2,Verified,2026-08-16
+South Africa,Southern Africa,Operating,3,5.2,2036,National Nuclear Regulator (NNR),Eskom (Koeberg) / Department of Mineral and Petroleum Resources / NNEECC,SAFARI-1,Verified,2026-08-16
 Uganda,East Africa,Preparing,2,8.4,2031,Atomic Energy Council (AEC),Ministry of Energy and Mineral Development,,Verified,2026-08-16
 Tanzania,East Africa,Preparing,2,,,Tanzania Atomic Energy Commission (TAEC),Ministry of Energy / TAEC,,Verified,2026-08-16
 Nigeria,West Africa,Preparing,2,4.0,,Nigerian Nuclear Regulatory Authority (NNRA),Nigeria Atomic Energy Commission (NAEC),NIRR-1,Verified,2026-08-16
 Zambia,Southern Africa,Exploring,1,1.0,,Radiation Protection Authority,Ministry of Energy / ZESCO,,Verified,2026-08-16
-Morocco,North Africa,Exploring,,,,"AMSSNuR (Agence Marocaine de Sûreté et de Sécurité Nucléaires et Radiologiques)",Ministry of Energy Transition / CNESTEN,CENM TRIGA Mark II,Verified,2026-08-16
-Algeria,North Africa,Exploring,,,,Commissariat à l'Énergie Atomique (COMENA),"Commissariat à l'Énergie Atomique (COMENA)","NUR / Es-Salam",Verified,2026-08-16
+Morocco,North Africa,Exploring,,,,AMSSNuR (Agence Marocaine de Sûreté et de Sécurité Nucléaires et Radiologiques),Ministry of Energy Transition / CNESTEN,CENM TRIGA Mark II,Verified,2026-08-16
+Algeria,North Africa,Exploring,,,,Commissariat à l'Énergie Atomique (COMENA),Commissariat à l'Énergie Atomique (COMENA),NUR / Es-Salam,Verified,2026-08-16
 Ethiopia,East Africa,Exploring,1,,,Ethiopian Technology Authority (ETA),Ethiopian Technology Authority (ETA),,Verified,2026-08-16
 Sudan,North Africa,Preparing,1,,,Sudanese Nuclear and Radiological Regulatory Authority (SNRRA),Ministry of Energy and Petroleum (NEPIO),,Verified,2026-08-16
-Tunisia,North Africa,Exploring,,,,"National Centre for Radiation Protection (CNRP)",STEG / CNSTN,,Verified,2026-08-16
+Tunisia,North Africa,Exploring,,,,National Centre for Radiation Protection (CNRP),STEG / CNSTN,,Verified,2026-08-16
 Zimbabwe,Southern Africa,Exploring,,,,Radiation Protection Authority of Zimbabwe (RPAZ),Ministry of Energy and Power Development,,Verified,2026-08-16
 Senegal,West Africa,Exploring,,,,"ARSN (Autorité Sénégalaise de Radioprotection, de Sûreté et de Sécurité Nucléaires)","Ministry of Energy, Petroleum and Mines (Energy Transition Directorate)",,Verified,2026-08-16
-Mali,West Africa,Exploring,,,,"Agence Malienne de Radioprotection (AMARAP)",Ministry of Energy and Water Resources,,Verified,2026-08-16
-Niger,West Africa,Exploring,,,,"Autorité de Régulation et de Sûreté Nucléaires (ARSN)",Ministry of Energy,,Verified,2026-08-16
-Eswatini,Southern Africa,Exploring,,,,"Ministry of Tourism and Environmental Affairs (nuclear regulatory authority being established)",Ministry of Natural Resources and Energy,,Verified,2026-08-16
-DR Congo,Central Africa,None,,,,"Comité National de Protection contre les Rayonnements Ionisants (CNPRI)",Ministry of Scientific Research and Technological Innovation / CREN-K,TRICO-II,Verified,2026-08-16
+Mali,West Africa,Exploring,,,,Agence Malienne de Radioprotection (AMARAP),Ministry of Energy and Water Resources,,Verified,2026-08-16
+Niger,West Africa,Exploring,,,,Autorité de Régulation et de Sûreté Nucléaires (ARSN),Ministry of Energy,,Verified,2026-08-16
+Eswatini,Southern Africa,Exploring,,,,Ministry of Tourism and Environmental Affairs (nuclear regulatory authority being established),Ministry of Natural Resources and Energy,,Verified,2026-08-16
+DR Congo,Central Africa,None,,,,Comité National de Protection contre les Rayonnements Ionisants (CNPRI),Ministry of Scientific Research and Technological Innovation / CREN-K,TRICO-II,Verified,2026-08-16

--- a/data/schema.json
+++ b/data/schema.json
@@ -78,7 +78,25 @@
         },
         "sources": { "type": "array", "minItems": 1, "items": { "type": "string" } },
         "confidence": { "type": "string", "enum": ["Verified", "Inference", "Speculation", "Unverified"] },
-        "last_verified": { "type": "string" }
+        "last_verified": { "type": "string" },
+        "assertions": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Per-claim sourcing and confidence. Each material factual claim gets its own source, confidence, and date. When present, this replaces the country-level confidence label.",
+          "items": {
+            "type": "object",
+            "required": ["field", "value", "confidence", "source_url", "observation_date", "verification_date"],
+            "additionalProperties": false,
+            "properties": {
+              "field": { "type": "string" },
+              "value": {},
+              "confidence": { "type": "string", "enum": ["Verified", "Inference", "Speculation", "Unverified"] },
+              "source_url": { "type": "string" },
+              "observation_date": { "type": "string", "pattern": "^\\d{4}(-\\d{2})?$" },
+              "verification_date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" }
+            }
+          }
+        }
       }
     }
   }

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -273,6 +273,28 @@ def _country_page(rec, stylesheet):
     if rec.get("notes"):
         notes = f"<h2>Summary</h2>\n<p>{esc(rec.get('notes'))}</p>\n"
 
+    assertions_html = ""
+    if rec.get("assertions"):
+        assertions_html = "<h2>Claims and confidence labels</h2>\n<ul class=\"assertion-list\">\n"
+        for a in rec["assertions"]:
+            val = a.get("value")
+            if isinstance(val, list):
+                val = ", ".join(str(v) for v in val)
+            elif val is None:
+                val = "n/a"
+            else:
+                val = str(val)
+            src = a.get("source_url", "")
+            link = f" <a href=\"{esc(src)}\" rel=\"noopener\" target=\"_blank\">source</a>" if src else ""
+            assertions_html += (
+                f"<li><span class=\"a-field\">{esc(a.get('field'))}</span>"
+                f"<span class=\"a-value\">{esc(val)}</span>"
+                f"<span class=\"a-conf\">{esc(a.get('confidence'))}</span>"
+                f"<span class=\"a-date\">observed {esc(a.get('observation_date'))} · verified {esc(a.get('verification_date'))}"
+                f"{link}</span></li>\n"
+            )
+        assertions_html += "</ul>\n"
+
     related = ""
     if rec.get("region"):
         related_links = []
@@ -314,7 +336,7 @@ def _country_page(rec, stylesheet):
         "      <div class=\"country-card\">\n"
         "<h2>" + esc(country) + " — key facts</h2>\n"
         "        <ul class=\"kv-list\">\n" + rows + "        </ul>\n"
-        + notes + events + sources + related +
+        + notes + events + assertions_html + sources + related +
         "        <p class=\"confidence-note\">Confidence labels: Verified (primary source), "
         "Inference (reasonable reading of verified evidence), Speculation (hypothesis), "
         "Unverified (reported, not confirmed). See the "

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -102,6 +102,32 @@ def check_string_list(value, field, country, min_items=0):
             fail(f"{country}: {field} entries must be strings")
 
 
+def check_assertion(assertion, country, index):
+    prefix = f"{country}: assertion #{index}"
+    if not isinstance(assertion, dict):
+        fail(f"{prefix} must be an object")
+        return
+    required = ["field", "value", "confidence", "source_url", "observation_date", "verification_date"]
+    for field in required:
+        if field not in assertion:
+            fail(f"{prefix} missing required field '{field}'")
+    field = assertion.get("field")
+    if not isinstance(field, str) or not field.strip():
+        fail(f"{prefix} field must be a non-empty string")
+    conf = assertion.get("confidence")
+    if conf not in CONFIDENCES:
+        fail(f"{prefix} invalid confidence '{conf}'")
+    src = assertion.get("source_url")
+    if not isinstance(src, str) or not src.startswith("http"):
+        fail(f"{prefix} source_url must be a URL starting with http")
+    obs = assertion.get("observation_date")
+    if not isinstance(obs, str) or not DATE_RE.match(obs):
+        fail(f"{prefix} observation_date must be YYYY or YYYY-MM, got '{obs}'")
+    ver = assertion.get("verification_date")
+    if not valid_date(ver):
+        fail(f"{prefix} verification_date must be an ISO date (YYYY-MM-DD), got '{ver}'")
+
+
 def main():
     global records
     schema = load_json(DATA / "schema.json")
@@ -202,6 +228,9 @@ def main():
         verified = record.get("last_verified")
         if not valid_date(verified):
             fail(f"{country}: last_verified must be an ISO date (YYYY-MM-DD), got '{verified}'")
+
+        for i, assertion in enumerate(record.get("assertions", []), start=1):
+            check_assertion(assertion, country, i)
 
     check_csv(dataset)
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -702,6 +702,38 @@ tbody tr.highlight { animation: flash 2s ease; }
   font-weight: 600;
 }
 
+.assertion-list { list-style: none; margin: 0; padding: 0; }
+
+.assertion-list li {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr auto;
+  gap: 8px 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.assertion-list li:last-child { border-bottom: none; }
+
+.assertion-list .a-field {
+  color: var(--text-2);
+  font-weight: 600;
+}
+
+.assertion-list .a-conf {
+  font-weight: 600;
+  color: var(--pr);
+}
+
+.assertion-list .a-date {
+  grid-column: 1 / -1;
+  color: var(--text-2);
+  font-size: 12px;
+}
+
+.assertion-list .a-value a { color: var(--pr); }
+
 .source-list { list-style: none; margin: 0; }
 
 .source-list li {


### PR DESCRIPTION
## Summary

Replaces the single country-wide confidence label with **per-claim sourcing and confidence** for the first 5 countries: Rwanda, South Africa, Egypt, Nigeria, Kenya.

Motivated by technical review feedback: a record may contain official facts, estimates, inference and secondary reporting, yet previously carried one overall `confidence` label (all 20 records "Verified"), hiding those distinctions. This PR gives each material claim its own `confidence`, `source_url`, `observation_date` and `verification_date`.

## Before / after — Rwanda

**Before:** one `"confidence": "Verified"` on the whole record; sources pointed at publisher homepages (`iaea.org`, `world-nuclear-news.org`).

**After:** `assertions` array with claim-level labels:

```json
{
  "field": "iaea_milestone_phase",
  "value": 2,
  "confidence": "Verified",
  "source_url": "https://www.iaea.org/newscenter/pressreleases/iaea-reviews-rwandas-nuclear-power-infrastructure-development",
  "observation_date": "2026-03",
  "verification_date": "2026-08-16"
},
{
  "field": "first_grid_target_year",
  "value": 2030,
  "confidence": "Inference",
  "source_url": "https://world-nuclear-news.org/articles/russia-and-rwanda-hold-first-nuclear-energy-joint-committee-meeting",
  "observation_date": "2026-07",
  "verification_date": "2026-08-16"
}
```

Material claims now split into `Verified` (primary sources), `Inference`, and `Unverified` where sources conflict — instead of a single blanket label.

## What changed

- **`data/assertions-schema.json`** (new): claim-level schema for `field`, `value`, `confidence`, `source_url`, `observation_date`, `verification_date`.
- **`data/schema.json`**: optional `assertions` array on country records (old top-level fields retained as a compatibility layer).
- **`scripts/validate.py`**: validates every assertion (required fields, confidence enum, URL, date formats).
- **`scripts/build_site.py` + `site/styles.css`**: country pages now render a "Claims and confidence labels" table with the per-claim source and confidence.
- **`data/afrpoweros.json`**: backfilled assertions for 5 countries; homepage-level sources replaced with precise article URLs (IAEA INIR press release, WNN IRP 2025 coverage, Necsa SAFARI-1 page, Rosatom/TASS grid-connection statement, nigatom.gov.ng, etc.).
- **`data/countries.csv`**: synced for Kenyan/South African field corrections below.

## Data corrections surfaced during backfill

While sourcing assertions, several values were corrected to latest verified figures:

| Country | Field | Before | After | Source |
|---|---|---|---|---|
| South Africa | `capacity_gw_planned` | 2.5 GW | 5.2 GW | IRP 2025 (WNN, Oct 2025) — 5,200 MW new nuclear by 2039 |
| South Africa | `first_grid_target_year` | 2032 | 2036 | IRP 2025 (WNN, Oct 2025) — initial 1,200 MW by 2036 |
| South Africa | Koeberg U2 licence event | "extended to 2044 (May 2025)" | "extended to 2045 (Nov 2025)" | WNN Koeberg unit 2 approval (Nov 2025) |
| Kenya | `capacity_gw_planned` | 1.0 GW | 2.0 GW (Unverified) | Siaya 2,000 MW, President statement at ICoNE (Mar 2026); 3,000 MW also reported |

## Migration note

The old top-level `confidence` field on each country record is retained **only for backward compatibility**. Records that carry `assertions` now derive their evidence profile from the per-claim labels instead — the single field is deprecated and will be dropped once all 20 countries are backfilled (remaining 15 tracked separately).

## Validation

- `python3 scripts/validate.py` — **OK: all checks passed**
- `python3 scripts/build_site.py` — builds all 20 country pages; assertion tables render for all 5 backfilled countries
- `data/countries.csv` consistency check enforced by validator — OK